### PR TITLE
Update documents to reflect that all relevant Altair repos are now in the Vega org

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -2,9 +2,9 @@
 
 ## Scope and Goals
 
-This is the organizational charter for [Vega](https://github.com/vega/vega), [Vega-Lite](https://github.com/vega/vega-lite), [Vega-Altair](https://github.com/altair-viz/altair), [Vega-Embed](https://github.com/vega/vega-embed), [Vega-Datasets](https://github.com/vega/vega-datasets), [Vega-Themes](https://github.com/vega/vega-themes), [Vega-Tooltips](https://github.com/vega/vega-tooltip), [Vega-Editor](https://github.com/vega/editor), [VL-Convert](https://github.com/vega/vl-convert), [VegaFusion](https://github.com/vega/vegafusion), [Altair-Tiles](https://github.com/altair-viz/altair_tiles), and [dash-vega-components](https://github.com/altair-viz/dash-vega-components). These projects are collectively referred to as the "Vega projects" in this document.
+This is the organizational charter for [Vega](https://github.com/vega/vega), [Vega-Lite](https://github.com/vega/vega-lite), [Vega-Altair](https://github.com/vega/altair), [Vega-Embed](https://github.com/vega/vega-embed), [Vega-Datasets](https://github.com/vega/vega-datasets), [Vega-Themes](https://github.com/vega/vega-themes), [Vega-Tooltips](https://github.com/vega/vega-tooltip), [Vega-Editor](https://github.com/vega/editor), [VL-Convert](https://github.com/vega/vl-convert), [VegaFusion](https://github.com/vega/vegafusion), [Altair-Tiles](https://github.com/vega/altair_tiles), and [dash-vega-components](https://github.com/vega/dash-vega-components). These projects are collectively referred to as the "Vega projects" in this document.
 
-The Vega projects are in the [vega](https://github.com/vega) and [altair-viz](https://github.com/altair-viz) GitHub organizations.
+All projects are part of the [vega](https://github.com/vega) GitHub organizations.
 
 ## Mission
 

--- a/project-docs/ADMINS.md
+++ b/project-docs/ADMINS.md
@@ -11,3 +11,7 @@ This document lists the Admins of the Project. Admins may be added once approved
 | Kanit Wongsuphasawat | @kanitw | - |
 | Lukas Hermann | @lsh | - |
 | Stefan Binder | @binste | - |
+| Christopher Davis | @ChristopherDavisUCI | - |
+| Joel Ostblom | @joelostblom  | - |
+| Jon Mease | @jonmmease | [Hex Technologies](https://hex.tech/) |
+| Mattijn van Hoek | @mattijn | - |

--- a/project-docs/ADMINS.md
+++ b/project-docs/ADMINS.md
@@ -2,9 +2,6 @@
 
 This document lists the Admins of the Project. Admins may be added once approved by the existing Admins as described in the [Governance document](GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's polices, including the [code of conduct](CODE_OF_CONDUCT.md).
 
-## Vega and Vega-Lite Admins
-
-This includes projects in the [vega](https://github.com/vega/) org.
 
 | **NAME** | **Handle** | **Affiliated Organization** |
 | --- | --- | --- |
@@ -13,15 +10,4 @@ This includes projects in the [vega](https://github.com/vega/) org.
 | Jeffrey Heer | @jheer | University of Washington |
 | Kanit Wongsuphasawat | @kanitw | - |
 | Lukas Hermann | @lsh | - |
-
-## Vega-Altair Admins
-
-This includes projects in the [altair-viz](https://github.com/altair-viz/) org.
-
-| **NAME** | **Handle** | **Affiliated Organization** |
-| --- | --- | --- |
-| Christopher Davis | @ChristopherDavisUCI | - |
-| Joel Ostblom | @joelostblom  | - |
-| Jon Mease | @jonmmease | [Hex Technologies](https://hex.tech/) |
-| Mattijn van Hoek | @mattijn | - |
 | Stefan Binder | @binste | - |

--- a/project-docs/MAINTAINERS.md
+++ b/project-docs/MAINTAINERS.md
@@ -2,10 +2,6 @@
 
 This document lists the Maintainers of the Project. Maintainers may be added once approved by the existing maintainers as described in the [Governance document](GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's polices, including the [code of conduct](CODE_OF_CONDUCT.md).
 
-## Vega and Vega-Lite Maintainers
-
-This includes projects in the [vega](https://github.com/vega/) org.
-
 | **NAME** | **Handle** | **Affiliated Organization** |
 | --- | --- | --- |
 | Arvind Satyanarayan | @arvind | MIT CSAIL |
@@ -20,16 +16,4 @@ This includes projects in the [vega](https://github.com/vega/) org.
 | Lukas Hermann | @lsh | - |
 | Mattijn van Hoek | @mattijn | - |
 | Younghoon Kim | @yhoonkim | - |
-| Stefan Binder | @binste | - |
-
-## Vega-Altair Maintainers
-
-This includes projects in the [altair-viz](https://github.com/altair-viz/) org.
-
-| **NAME** | **Handle** | **Affiliated Organization** |
-| --- | --- | --- |
-| Christopher Davis | @ChristopherDavisUCI | - |
-| Joel Ostblom | @joelostblom  | - |
-| Jon Mease | @jonmmease | [Hex Technologies](https://hex.tech/) |
-| Mattijn van Hoek | @mattijn | - |
 | Stefan Binder | @binste | - |

--- a/project-docs/MAINTAINERS.md
+++ b/project-docs/MAINTAINERS.md
@@ -17,3 +17,4 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | Mattijn van Hoek | @mattijn | - |
 | Younghoon Kim | @yhoonkim | - |
 | Stefan Binder | @binste | - |
+| Christopher Davis | @ChristopherDavisUCI | - |


### PR DESCRIPTION
I've replaced or removed all mentions of the altair-viz org.

@joelostblom, @jonmmease, @mattijn, @ChristopherDavisUCI were not admins of the Vega org (they were not in the list and they do not have "Owner" rights) but were admins of the Altair org. In addition, @ChristopherDavisUCI was not listed as a maintainer of the Vega org.

The usual process to add maintainers and admins would be through the Slack voting. We can do that but I'd argue that this is caused by the merge of the two organisations and hence the two lists should be merged into one which is what I've done in this PR. So it's not really an addition of new maintainers or admins. Existing Vega maintainers and owners also don't have to go through the voting process to become maintainers of the repos which I moved over from altair-viz.

What do you think? I've added all steering committee members as approvers to this PR so we can deal with it this way but let me know if you'd prefer a different approach! :)