### PR TITLE
Remove sentence about affiliation from steering committee

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -1,6 +1,6 @@
 # Steering Committee
 
-This document lists the members of the Organization's Steering Committee. Voting members may be added once approved by the Steering Committee as described in the [charter](CHARTER.md). By adding your name to this list you are agreeing to abide by all Organization polices, including the [charter](CHARTER.md) and the [code of conduct](CODE_OF_CONDUCT.md). If you are serving on the Steering Committee because of your affiliation with another organization (designated below), you represent that you have authority to bind that organization to these policies.
+This document lists the members of the Organization's Steering Committee. Voting members may be added once approved by the Steering Committee as described in the [charter](CHARTER.md). By adding your name to this list you are agreeing to abide by all Organization polices, including the [charter](CHARTER.md) and the [code of conduct](CODE_OF_CONDUCT.md).
 
 | **NAME** | **Handle** | **Affiliated Organization** |
 | --- | --- | --- |


### PR DESCRIPTION
I propose to remove this sentence as it may have some unintended implications. First, it sounds like we are asking organizations to commit to the policies when it's always the individuals. I think the fact that organizations have to allow individuals to bind themselves to our policies is implied already. The bigger issue with this sentence is that it talks about "because of your affiliation" which makes it sound like the position is bound to the organization, not the individual. This could the interpreted as saying that if the person leaves the organization, the organization gets to fill the slot rather than the person continuing to be on the steering committee.