### PR TITLE
Add Dan Redding to maintainers list

### DIFF
--- a/project-docs/MAINTAINERS.md
+++ b/project-docs/MAINTAINERS.md
@@ -19,3 +19,4 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | Younghoon Kim | @yhoonkim | - |
 | Stefan Binder | @binste | - |
 | Christopher Davis | @ChristopherDavisUCI | - |
+| Dan Redding | @dangotbanned | - |


### PR DESCRIPTION
@dangotbanned The vote to add you as a maintainer was positive and so following the procedure outlined in https://github.com/vega/.github?tab=readme-ov-file#adding-maintainers, this PR adds you to the official list of maintainers 🥳  Thanks again for all the hard work you put into Altair!

1. Accept the invite into the Vega Org
2. I'll add you as a reviewer of this PR
3. Check if you want to add an affiliation in this PR.
4. Feel free to merge the PR confirming that you  agree with the governance documents

In case you can't merge in this repo or in Altair, let me know! First time I'm adding someone after we've changed our governance and the access rights management.

In case you've joined the Vega slack, let me know and I'll add you to the maintainers channel. No need for this, just if you want to. Almost all conversations are happening on GitHub anyway.