### PR TITLE
Remove binste from steering committee

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -4,7 +4,6 @@ This document lists the members of the Organization's Steering Committee. Voting
 
 | **NAME** | **Handle** | **Affiliated Organization** |
 | --- | --- | --- |
-| Stefan Binder (Chair) | @binste | - |
 | Dominik Moritz (Chair) | @domoritz | Carnegie Mellon University, Apple |
 | Jeffrey Heer | @jheer | University of Washington |
 | Kanit Wongsuphasawat | @kanitw | - |


### PR DESCRIPTION
As announced on Slack, for vega-unrelated reasons, I will allocate my time a bit differently in the coming months and will step down from the steering committee. I'll keep cheering on Vega from the sidelines as a happy user and maybe a PR every once in a while 😃 