### PR TITLE
docs: Add security policy for the Vega org

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,6 @@ To report a security issue privately, please use the GitHub Security Advisory ["
 
 A Vega [maintainer](https://github.com/vega/.github/blob/main/project-docs/MAINTAINERS.md) will send a response indicating next steps in handling your report. After the initial reply, the team will keep you informed of the progress towards a fix and announcement, and may ask for additional information or guidance.
 
-You can also report a vulnerability in Vega Javascript packages through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability", or in Python packages through the [PyPI form](https://pypi.org/security/)
-
 ## Languages
 
 Communications should be in English.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security
+
+The Vega team and community take security bugs in [Vega languages and tools](https://github.com/vega) seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a security issue privately, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/vega/.github/security/advisories/new) tab.
+
+A Vega [maintainer](https://github.com/vega/.github/blob/main/project-docs/MAINTAINERS.md) will send a response indicating next steps in handling your report. After the initial reply, the team will keep you informed of the progress towards a fix and announcement, and may ask for additional information or guidance.
+
+You can also report a vulnerability in Vega Javascript packages through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability", or in Python packages through the [PyPI form](https://pypi.org/security/)
+
+## Languages
+
+Communications should be in English.
+
+## Learning More About Security
+
+To learn more about security measures in Vega, see the documentation on using an expression [`interpreter`](https://vega.github.io/vega/usage/interpreter/) for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) compliance, or [`loader`](https://github.com/vega/vega/tree/main/packages/vega-loader) for opening network or filesystem resources.


### PR DESCRIPTION
## Motivation

- Make it easy for researchers and engineers to have a safe path to reporting security vulnerabilities
- Keep Vega and its dependents (Vega-Lite, vega-embed, altair, etc) secure

## Changes

- Add a `SECURITY.md` ([Security Policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)), following a slack discussion in the Maintainers channel. This is based on
  - Electron https://github.com/electron/electron/blob/main/SECURITY.md
  - Microsoft: https://github.com/microsoft/.github/blob/main/SECURITY.md
- I modified the original proposal from https://github.com/vega/vega/pull/4008 to be less specific to Javascript . It will point security advisories for the whole org to `.github` . It doesn't look like there's a way to transfer advisories between repositories, so I'm mixed about whether we should link to 1 item from `.github`, vs encourage people to file an issue per repository. 