### PR TITLE
docs: Add Datadog affiliation for Cameron Yick

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -12,4 +12,4 @@ This document lists the members of the Organization's Steering Committee. Voting
 | Jon Mease | @jonmmease | [Hex Technologies](https://hex.tech/) |
 | Mattijn van Hoek | @mattijn | - |
 | Christopher Davis | @ChristopherDavisUCI | - |
-| Cameron Yick | @hydrosquall |	- |
+| Cameron Yick | @hydrosquall | [Datadog](https://www.datadoghq.com/) |

--- a/project-docs/MAINTAINERS.md
+++ b/project-docs/MAINTAINERS.md
@@ -5,7 +5,7 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | **NAME** | **Handle** | **Affiliated Organization** |
 | --- | --- | --- |
 | Arvind Satyanarayan | @arvind | MIT CSAIL |
-| Cameron Yick | @hydrosquall | - |
+| Cameron Yick | @hydrosquall | [Datadog](https://www.datadoghq.com/) |
 | Dominik Moritz | @domoritz | Carnegie Mellon University, Apple |
 | Fan Du | @fandu-db | - |
 | Jeffrey Heer | @jheer | University of Washington |


### PR DESCRIPTION
## Motivation

I've confirmed with our open-source team that I can list my work affiliation ([Datadog](https://docs.datadoghq.com/dashboards/widgets/wildcard/)) with Vega.
