### PR TITLE
Add Jonathan Zong and Josh Pollock as Maintainers

### DIFF
--- a/project-docs/MAINTAINERS.md
+++ b/project-docs/MAINTAINERS.md
@@ -21,3 +21,5 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | Christopher Davis | @ChristopherDavisUCI | - |
 | Dan Redding | @dangotbanned | - |
 | Daniel Sorid | @dsmedia | - |
+| Jonathan Zong | @jonathanzong | MIT CSAIL |
+| Josh Pollock | @joshpoll | MIT CSAIL |


### PR DESCRIPTION
The vote to add @jonathanzong and @joshpoll passed! So, following [our procedures](https://github.com/vega/.github?tab=readme-ov-file#adding-maintainers), this PR adds them to the official list of maintainers! 🥳 

Thanks for the hard work you both put in to implement Vega-Lite's animation features (https://github.com/vega/vega-lite/pull/8921). Here are the next steps:

1. Accept the invite into the Vega Org
2. I'll add you as a reviewer of this PR
3. Feel free to merge the PR confirming that you agree with the governance documents
4. Once merged, I'll add you to the maintainers channel in the Vega Slack.